### PR TITLE
[Feature] 기본 엔티티 작성 및 연관관계 매핑

### DIFF
--- a/src/main/java/com/hufs_cheongwon/domain/Admin.java
+++ b/src/main/java/com/hufs_cheongwon/domain/Admin.java
@@ -1,0 +1,62 @@
+package com.hufs_cheongwon.domain;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Admin extends BaseTimeEntity{
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column
+    private String departure;
+
+    @Column
+    private String role; // 부서에서의 직책
+
+    @Column
+    private String name;
+
+    @Column
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column
+    private String phoneNumber;
+
+    @OneToMany(mappedBy = "admin", cascade = CascadeType.ALL)
+    private List<Response> responses = new ArrayList<>();
+
+    @Builder
+    public Admin(String departure, String role, String name, String email, String password, String phoneNumber) {
+        this.departure = departure;
+        this.role = role;
+        this.name = name;
+        this.email = email;
+        this.password = password;
+        this.phoneNumber = phoneNumber;
+    }
+
+    /**
+     * 연관관계 설정 메소드
+     */
+    public void addResponse(Response response) {
+        this.responses.add(response);
+    }
+}

--- a/src/main/java/com/hufs_cheongwon/domain/Agreement.java
+++ b/src/main/java/com/hufs_cheongwon/domain/Agreement.java
@@ -1,0 +1,39 @@
+package com.hufs_cheongwon.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Agreement extends BaseTimeEntity{
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "users_id", nullable = false)
+    private Users users;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "petition_id", nullable = false)
+    private Petition petition;
+
+    @Builder
+    public Agreement(Users users, Petition petition) {
+        this.users = users;
+        users.addAgreement(this);
+        this.petition = petition;
+        petition.addAgreement(this);
+        petition.addAgreeCount(1);
+    }
+}

--- a/src/main/java/com/hufs_cheongwon/domain/Category.java
+++ b/src/main/java/com/hufs_cheongwon/domain/Category.java
@@ -1,0 +1,32 @@
+package com.hufs_cheongwon.domain;
+
+public enum Category {
+    ALL("전체"),
+    EDUCATION("교육")
+    ;
+
+    private final String displayName;
+
+    Category(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    // 화면에 표시되는 이름으로 enum 찾기
+    public static Category fromDisplayName(String displayName) {
+        for (Category type : values()) {
+            if (type.getDisplayName().equals(displayName)) {
+                return type;
+            }
+        }
+        throw new IllegalArgumentException("Unknown category display name: " + displayName);
+    }
+
+    // enum 이름을 소문자로 변환 (URL 경로나 API 요청에서 사용)
+    public String toLowerCaseString() {
+        return this.name().toLowerCase();
+    }
+}

--- a/src/main/java/com/hufs_cheongwon/domain/Petition.java
+++ b/src/main/java/com/hufs_cheongwon/domain/Petition.java
@@ -1,0 +1,100 @@
+package com.hufs_cheongwon.domain;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Petition extends BaseTimeEntity{
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Category category;
+
+    @Lob
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private PetitionStatus petitionStatus;
+
+    @Column
+    private Integer agree_count = 0;
+
+    @Column
+    private Integer view_count = 0;
+
+    @Column
+    private Integer report_count = 0;
+
+    //userId
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "users_id", nullable = false)
+    private Users users; // 작성자
+
+    @OneToMany(mappedBy = "petition", cascade = CascadeType.ALL)
+    private List<Agreement> agreements = new ArrayList<>();
+
+    @OneToMany(mappedBy = "petition", cascade = CascadeType.ALL)
+    private List<Report> reports = new ArrayList<>();
+
+    @Builder
+    public Petition(Users user, String title, Category category, String content, PetitionStatus petitionStatus) {
+        this.title = title;
+        this.category = category;
+        this.content = content;
+        this.petitionStatus = petitionStatus;
+        this.users = user;
+        user.addPetition(this);
+    }
+
+    /**
+     * 비즈니스 메소드
+     */
+    public void addAgreeCount(int count) {
+        this.agree_count += count;
+    }
+    public void addViewCount(int count) {
+        this.view_count += count;
+    }
+    public void addReportCount(int count) {
+        this.report_count += count;
+    }
+
+    /**
+     * 연관관계 메소드
+     */
+    public void addReport(Report report) {
+        this.reports.add(report);
+    }
+
+    public void addAgreement(Agreement agreement) {
+        this.agreements.add(agreement);
+    }
+}

--- a/src/main/java/com/hufs_cheongwon/domain/PetitionStatus.java
+++ b/src/main/java/com/hufs_cheongwon/domain/PetitionStatus.java
@@ -1,0 +1,5 @@
+package com.hufs_cheongwon.domain;
+
+public enum PetitionStatus {
+    ONGOING, EXPIRED, WAITING, ANSWER_COMPLETED
+}

--- a/src/main/java/com/hufs_cheongwon/domain/Report.java
+++ b/src/main/java/com/hufs_cheongwon/domain/Report.java
@@ -1,0 +1,40 @@
+package com.hufs_cheongwon.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Report extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "users_id", nullable = false)
+    private Users users;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "petition_id", nullable = false)
+    private Petition petition;
+
+    @Builder
+    public Report(Long id, Users users, Petition petition) {
+        this.id = id;
+        this.users = users;
+        users.addReport(this);
+        this.petition = petition;
+        petition.addReport(this);
+        petition.addReportCount(1);
+    }
+}

--- a/src/main/java/com/hufs_cheongwon/domain/Response.java
+++ b/src/main/java/com/hufs_cheongwon/domain/Response.java
@@ -1,0 +1,38 @@
+package com.hufs_cheongwon.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Response extends BaseTimeEntity{
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "admin_id", nullable = false)
+    private Admin admin;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "petition_id", nullable = false)
+    private Petition petition;
+
+    @Builder
+    public Response(Admin admin, Petition petition) {
+        this.admin = admin;
+        admin.addResponse(this);
+        this.petition = petition;
+    }
+}

--- a/src/main/java/com/hufs_cheongwon/domain/Users.java
+++ b/src/main/java/com/hufs_cheongwon/domain/Users.java
@@ -1,15 +1,20 @@
 package com.hufs_cheongwon.domain;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Getter
@@ -31,7 +36,21 @@ public class Users extends BaseTimeEntity {
     @Column(nullable = false)
     private String name;
 
+    @Column
     private String studentNumber;
+
+    @Column
+    @Setter
+    private String status;  //TODO: enum화 하기
+
+    @OneToMany(mappedBy = "users", cascade = CascadeType.ALL)
+    private List<Petition> petitions = new ArrayList<>();
+
+    @OneToMany(mappedBy = "users", cascade = CascadeType.ALL)
+    private List<Agreement> agreements = new ArrayList<>();
+
+    @OneToMany(mappedBy = "users", cascade = CascadeType.ALL)
+    private List<Report> reports = new ArrayList<>();
 
     @Builder
     public Users(String email, String password, String name, String studentNumber) {
@@ -39,5 +58,21 @@ public class Users extends BaseTimeEntity {
         this.password = password;
         this.name = name;
         this.studentNumber = studentNumber;
+        this.status = "Active";
+    }
+
+    /**
+     * 연관관계 설정 메소드
+     */
+    public void addPetition(Petition petition) {
+        petitions.add(petition);
+    }
+
+    public void addAgreement(Agreement agreement) {
+        agreements.add(agreement);
+    }
+
+    public void addReport(Report report) {
+        reports.add(report);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:h2:mem:testdb
+    url: jdbc:h2:tcp://localhost/~/cheongwon
     username: sa
     password:
     driver-class-name: org.h2.Driver


### PR DESCRIPTION
### 연관 이슈: #2

### 구현 설명
- 양방향 매핑 설정
- 청원 동의 및 신고 시 카운트 자동 증가
- 엔티티 생성자 사용 제한 및 빌더 메소드 사용

### H2 DB 연결 방법
![스크린샷 2025-03-07 190524](https://github.com/user-attachments/assets/03aef690-61cb-4880-a47f-1d8e5cd481b4)
- 위 사진에서 jpaShop 부분 cheongwon으로 바꾸면 됩니다
- 원하는 이름으로 하고 싶으면 yml 파일도 같이 수정

## ERD

![스크린샷 2025-03-07 184058](https://github.com/user-attachments/assets/2c3ef7ae-5ff4-4c3e-846b-2c0da1e37785)
- 위에서 Users에 status 추가했으