### PR TITLE
[Refactor]: 에러 핸들러의 일부 메소드를 해당 에러의 메시지를 사용하도록 수정

### DIFF
--- a/src/main/java/com/hufs_cheongwon/web/apiResponse/error/ErrorResponse.java
+++ b/src/main/java/com/hufs_cheongwon/web/apiResponse/error/ErrorResponse.java
@@ -7,21 +7,21 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.util.Map;
+import lombok.Setter;
 
 @Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@Setter
 public class ErrorResponse {
 
     private Boolean isSuccess;
     private String code;
     private String message;
 
+
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private Map<String, String> validation;
 
-    public void setValidation(Map<String, String> validation) {
-        this.validation = validation;
-    }
 }


### PR DESCRIPTION
## #️⃣ Issue Number

#40

## 📝 요약(Summary)

- e의 메시지를 가져와 사용
- 쿠키 관련 에러도 처리하도록 구현
