### PR TITLE
[Refactor] 사용자 탈퇴 리팩토링

### DIFF
--- a/src/main/java/com/hufs_cheongwon/common/Constant.java
+++ b/src/main/java/com/hufs_cheongwon/common/Constant.java
@@ -11,4 +11,6 @@ public class Constant {
     public static final Integer THRESHOLDAGREEMENT = 10;
 
     public static final Integer EXPIRED_DATE = 1;
+
+    public static final Integer USER_WITHDRAW_DATE = 1;
 }

--- a/src/main/java/com/hufs_cheongwon/common/Util.java
+++ b/src/main/java/com/hufs_cheongwon/common/Util.java
@@ -5,8 +5,19 @@ public class Util {
      * 이메일 마스킹 유틸: abcde@domain.com → a***@d***
      */
     public static String maskEmail(String email) {
-        if (email == null || !email.contains("@")) return "invalid";
+
+        if (email == null) return "invalid";
+        else if (email.equals("unknown")) return "unknown";
+        else if (!email.contains("@")) return "invalid";
+
         String[] parts = email.split("@");
-        return parts[0].charAt(0) + "***@" + parts[1].charAt(0) + "***";
+        String username = parts[0];
+        String domain = parts[1];
+
+        String visibleUsername = username.length() <= 3
+                ? username
+                : username.substring(0, 3);
+
+        return visibleUsername + "***@" + domain.charAt(0) + "***";
     }
 }

--- a/src/main/java/com/hufs_cheongwon/common/config/SecurityConfig.java
+++ b/src/main/java/com/hufs_cheongwon/common/config/SecurityConfig.java
@@ -53,7 +53,8 @@ public class SecurityConfig {
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests((auth) -> auth
                         .requestMatchers("/admin/login","/admin/pwd","/user/test","/user/pwd/update").permitAll()
-                        .requestMatchers("/petitions/{petition_id}/agree", "/petitions/{petition_id}/report", "/petitions/new", "/user/logout", "/user/delete").hasRole("USER")
+                        .requestMatchers("/petitions/{petition_id}/agree", "/petitions/{petition_id}/report", "/petitions/new",
+                                "/user/logout", "/user/delete", "/user/withdraw").hasRole("USER")
                         .requestMatchers("/admin/**").hasAnyRole("ADMIN", "SUPER")
                         .requestMatchers("/super/**").hasRole("SUPER")
                         .anyRequest().permitAll())

--- a/src/main/java/com/hufs_cheongwon/common/scheduler/UsersStatusScheduler.java
+++ b/src/main/java/com/hufs_cheongwon/common/scheduler/UsersStatusScheduler.java
@@ -1,0 +1,41 @@
+package com.hufs_cheongwon.common.scheduler;
+
+import com.hufs_cheongwon.common.Constant;
+import com.hufs_cheongwon.common.Util;
+import com.hufs_cheongwon.domain.Users;
+import com.hufs_cheongwon.domain.enums.UsersStatus;
+import com.hufs_cheongwon.repository.UsersRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class UsersStatusScheduler {
+    private final UsersRepository usersRepository;
+
+    /**
+     * 매일 자정에 탈퇴 30일 경과한 유저 정보 삭제
+     */
+    @Scheduled(cron = "0 0 0 * * *")
+    public void eraseInactiveUserInfo() {
+        log.info("Withdrawn user info erase job started at: {}", LocalDateTime.now());
+
+        LocalDateTime cutoffDate = LocalDateTime.now().minusDays(Constant.USER_WITHDRAW_DATE);
+        List<Users> targetUsers = usersRepository.findAllByUsersStatusAndInactiveAtBefore(
+                UsersStatus.INACTIVE, cutoffDate);
+
+        for (Users user : targetUsers) {
+            user.eraseUserInfo();
+            user.changeUserStatus(UsersStatus.DELETED);
+            log.info("탈퇴 30일 경과 유저 정보 삭제: email(before)={}", Util.maskEmail(user.getEmail()));
+        }
+
+        usersRepository.saveAll(targetUsers);
+    }
+}

--- a/src/main/java/com/hufs_cheongwon/common/security/CustomUserDetailsService.java
+++ b/src/main/java/com/hufs_cheongwon/common/security/CustomUserDetailsService.java
@@ -34,7 +34,8 @@ public class CustomUserDetailsService implements UserDetailsService {
                     return new ResourceNotFoundException(ErrorStatus.USER_NOT_FOUND);
                 });
 
-        if (user.getUsersStatus() == UsersStatus.DELETED) {
+        // 탈퇴한 사용자라면 예외 던지기
+        if (user.getUsersStatus() != UsersStatus.ACTIVE) {
             throw new InvalidStateException(ErrorStatus.WITHDRAWN_USER);
         }
         return CustomUserDetails.from(user);

--- a/src/main/java/com/hufs_cheongwon/common/security/CustomUserDetailsService.java
+++ b/src/main/java/com/hufs_cheongwon/common/security/CustomUserDetailsService.java
@@ -2,8 +2,10 @@ package com.hufs_cheongwon.common.security;
 
 import com.hufs_cheongwon.common.Constant;
 import com.hufs_cheongwon.common.Util;
+import com.hufs_cheongwon.common.exception.InvalidStateException;
 import com.hufs_cheongwon.common.exception.ResourceNotFoundException;
 import com.hufs_cheongwon.domain.Users;
+import com.hufs_cheongwon.domain.enums.UsersStatus;
 import com.hufs_cheongwon.repository.UsersRepository;
 import com.hufs_cheongwon.web.apiResponse.error.ErrorStatus;
 import lombok.RequiredArgsConstructor;
@@ -31,6 +33,10 @@ public class CustomUserDetailsService implements UserDetailsService {
                     log.warn("[Authentication] 사용자 정보 없음 - 이메일: {}", Util.maskEmail(username));
                     return new ResourceNotFoundException(ErrorStatus.USER_NOT_FOUND);
                 });
+
+        if (user.getUsersStatus() == UsersStatus.DELETED) {
+            throw new InvalidStateException(ErrorStatus.WITHDRAWN_USER);
+        }
         return CustomUserDetails.from(user);
     }
 }

--- a/src/main/java/com/hufs_cheongwon/common/security/JwtUserLoginFilter.java
+++ b/src/main/java/com/hufs_cheongwon/common/security/JwtUserLoginFilter.java
@@ -106,15 +106,7 @@ public class JwtUserLoginFilter extends UsernamePasswordAuthenticationFilter {
         log.warn("[Authentication] 로그인 실패 - 사유: {}", failed.getMessage());
         AuthenticationException exception = new AuthenticationException(objectMapper);
 
-        if (failed.getCause() instanceof ResourceNotFoundException) {
-            log.warn("[Authentication] 로그인 실패 - 사용자 정보 없음");
-            exception.sendErrorResponse(response, ErrorStatus.USER_NOT_FOUND);
-        } else if (failed instanceof BadCredentialsException) {
-            log.warn("[Authentication] 로그인 실패 - 비밀번호 불일치");
-            exception.sendErrorResponse(response, ErrorStatus.PASSWORD_WRONG);
-        } else {
-            log.error("[Authentication] 로그인 실패 - 알 수 없는 오류");
-            exception.sendErrorResponse(response, ErrorStatus._LOGIN_FAILURE);
-        }
+        //로그인 실패 이유 알 수 없도록 일반적인 오류 메세지 보내기
+        exception.sendErrorResponse(response, ErrorStatus._LOGIN_FAILURE);
     }
 }

--- a/src/main/java/com/hufs_cheongwon/domain/Users.java
+++ b/src/main/java/com/hufs_cheongwon/domain/Users.java
@@ -3,6 +3,7 @@ package com.hufs_cheongwon.domain;
 import com.hufs_cheongwon.domain.enums.UsersStatus;
 import jakarta.persistence.*;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
@@ -34,6 +35,9 @@ public class Users extends BaseTimeEntity {
 
     @Column
     private String studentNumber;
+
+    @Column
+    private LocalDateTime deleteAt;
 
     @Column
     @Setter
@@ -87,7 +91,17 @@ public class Users extends BaseTimeEntity {
     /**
      * 비즈니스 메소드
      */
+    // 회원 상태 변경
     public void changeUserStatus(UsersStatus status){
         this.usersStatus = status;
+    }
+
+    // 회원 정보 지우기
+    public void eraseUserInfo() {
+        this.email = "unknown";
+        this.password = "DELETED_USER_PASSWORD";
+        this.name = null;
+        this.studentNumber = null;
+        this.deleteAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/hufs_cheongwon/domain/Users.java
+++ b/src/main/java/com/hufs_cheongwon/domain/Users.java
@@ -37,6 +37,9 @@ public class Users extends BaseTimeEntity {
     private String studentNumber;
 
     @Column
+    private LocalDateTime inactiveAt;
+
+    @Column
     private LocalDateTime deleteAt;
 
     @Column
@@ -94,6 +97,10 @@ public class Users extends BaseTimeEntity {
     // 회원 상태 변경
     public void changeUserStatus(UsersStatus status){
         this.usersStatus = status;
+    }
+
+    public void setInactiveAt() {
+        this.inactiveAt = LocalDateTime.now();
     }
 
     // 회원 정보 지우기

--- a/src/main/java/com/hufs_cheongwon/repository/UsersRepository.java
+++ b/src/main/java/com/hufs_cheongwon/repository/UsersRepository.java
@@ -1,8 +1,11 @@
 package com.hufs_cheongwon.repository;
 
 import com.hufs_cheongwon.domain.Users;
+import com.hufs_cheongwon.domain.enums.UsersStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface UsersRepository extends JpaRepository<Users, Long> {
@@ -12,4 +15,7 @@ public interface UsersRepository extends JpaRepository<Users, Long> {
     Optional<Users> findByEmail(String email);
 
     void deleteByEmail(String email);
+
+    // usersStatus == INACTIVE && inactiveAt < 30일 전
+    List<Users> findAllByUsersStatusAndInactiveAtBefore(UsersStatus usersStatus, LocalDateTime cutoffDate);
 }

--- a/src/main/java/com/hufs_cheongwon/service/UsersService.java
+++ b/src/main/java/com/hufs_cheongwon/service/UsersService.java
@@ -54,13 +54,12 @@ public class UsersService {
             log.warn("[회원가입 실패] 이메일 불일치 - tokenEmail={}, requestEmail={}", Util.maskEmail(tokenEmail), Util.maskEmail(email));
             throw new ResourceNotFoundException(ErrorStatus.EMAIL_UNCERTIFIED);
         }
-        System.out.println(tokenEmail+email);
 
         // 존재하는 이메일인지 확인
         Users existingUser = usersRepository.findByEmail(email).orElse(null);
         if (existingUser != null){
+            // 기존 비활성 유저: 정보 갱신 + 상태 복구
             if (existingUser.getUsersStatus() == UsersStatus.INACTIVE) {
-                // 기존 비활성 유저: 정보 갱신 + 상태 복구
                 existingUser.setEncodedPassword(bCryptPasswordEncoder.encode(password));
                 existingUser.changeUserStatus(UsersStatus.ACTIVE);
                 log.info("[회원 재가입] 기존 INACTIVE 사용자 상태 복원 - email={}", Util.maskEmail(email));
@@ -69,10 +68,9 @@ public class UsersService {
                         .role(existingUser.getRole())
                         .email(existingUser.getEmail())
                         .build();
-            } else {
-                //ACTIVE 중복 에러
-                throw new DuplicateResourceException(ErrorStatus.EMAIL_DUPLICATED);
             }
+            // ACTIVE 중복 에러
+            throw new DuplicateResourceException(ErrorStatus.EMAIL_DUPLICATED);
         }
 
         // 새로운 유저

--- a/src/main/java/com/hufs_cheongwon/web/apiResponse/error/ErrorStatus.java
+++ b/src/main/java/com/hufs_cheongwon/web/apiResponse/error/ErrorStatus.java
@@ -39,6 +39,7 @@ public enum ErrorStatus {
     EMAIL_NOT_SCHOOL(HttpStatus.BAD_REQUEST, StatusCode.USER.getCode(4018), "학교 이메일이 아닙니다."),
     AUTH_CODE_SEND_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, StatusCode.USER.getCode(4019), "인증번호 발송에 실패하였습니다."),
     AUTH_CODE_NOT_RECEIVED(HttpStatus.BAD_REQUEST, StatusCode.USER.getCode(4020), "인증코드를 받은 적이 없는 사용자입니다."),
+    WITHDRAWN_USER(HttpStatus.BAD_REQUEST, StatusCode.USER.getCode(4021), "이미 탈퇴된 계정입니다."),
 
     PETITION_NOT_FOUND(HttpStatus.NOT_FOUND, StatusCode.PETITION.getCode(4001), "해당 청원이 존재하지 않습니다."),
     PETITION_NOT_ONGOING(HttpStatus.BAD_REQUEST, StatusCode.PETITION.getCode(4002), "진행 중인 청원만 동의할 수 있습니다."),

--- a/src/main/java/com/hufs_cheongwon/web/apiResponse/success/SuccessStatus.java
+++ b/src/main/java/com/hufs_cheongwon/web/apiResponse/success/SuccessStatus.java
@@ -16,7 +16,7 @@ public enum SuccessStatus {
     SIGN_IN_SUCCESS(HttpStatus.OK, StatusCode.USER.getCode(2011), "성공적으로 회원가입되었습니다."),
     USER_LOGOUT_SUCCESS(HttpStatus.OK, StatusCode.USER.getCode(2001), "성공적으로 로그아웃되었습니다."),
     USER_EDIT_SUCCESS(HttpStatus.OK, StatusCode.USER.getCode(2002), "유저 정보가 성공적으로 변경되었습니다."),
-    USER_SING_OUT_SUCCESS(HttpStatus.OK, StatusCode.USER.getCode(2003), "성공적으로 탈퇴되었습니다."),
+    USER_SIGN_OUT_SUCCESS(HttpStatus.OK, StatusCode.USER.getCode(2003), "성공적으로 탈퇴되었습니다."),
     REISSUE_TOKEN_SUCCESS(HttpStatus.OK, StatusCode.USER.getCode(2003), "토큰이 성공적으로 재발급되었습니다."),
     USER_INFO_RETRIEVED(HttpStatus.OK, StatusCode.USER.getCode(2004), "유저 정보가 조회되었습니다."),
     USER_LOGIN_SUCCESS(HttpStatus.OK, StatusCode.USER.getCode(2005), "성공적으로 로그인되었습니다."),

--- a/src/main/java/com/hufs_cheongwon/web/controller/UserController.java
+++ b/src/main/java/com/hufs_cheongwon/web/controller/UserController.java
@@ -123,21 +123,21 @@ public class UserController {
     }
 
     /**
-     * 회원 탈퇴
+     * 회원 탈퇴 (soft-delete)
      */
-    @PostMapping("/delete")
-    public ApiResponse<Void> deleteUser(HttpServletRequest request, @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+    @PostMapping("/withdraw")
+    public ApiResponse<Void> withdrawUser(HttpServletRequest request) {
         //헤더에서 access token 추출
         String accessToken = jwtUtil.resolveAccessToken(request);
         String username = jwtUtil.getUsername(accessToken);
 
         usersService.withdrawUser(username, accessToken);
 
-        return ApiResponse.onSuccess(SuccessStatus.USER_SING_OUT_SUCCESS, null);
+        return ApiResponse.onSuccess(SuccessStatus.USER_SIGN_OUT_SUCCESS, null);
     }
 
     /**
-     * 비밀 번호 찾기 위한 본인 인증
+     * 비밀 번호 변경
      */
     @PostMapping("/pwd/update")
     public ApiResponse<AuthInfoResponse> updatePassword(@Valid @RequestBody LoginRequest request,

--- a/src/main/java/com/hufs_cheongwon/web/dto/response/AnswerResponse.java
+++ b/src/main/java/com/hufs_cheongwon/web/dto/response/AnswerResponse.java
@@ -1,5 +1,6 @@
 package com.hufs_cheongwon.web.dto.response;
 
+import com.hufs_cheongwon.common.Util;
 import com.hufs_cheongwon.domain.Admin;
 import com.hufs_cheongwon.domain.Response;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -45,7 +46,7 @@ public class AnswerResponse {
                         .adminId(admin.getId())
                         .departure(admin.getDeparture())
                         .role(admin.getRole())
-                        .email(admin.getEmail())
+                        .email(Util.maskEmail(admin.getEmail()))
                         .phoneNumber(admin.getPhoneNumber())
                         .build())
                 .build();

--- a/src/main/java/com/hufs_cheongwon/web/dto/response/PetitionResponse.java
+++ b/src/main/java/com/hufs_cheongwon/web/dto/response/PetitionResponse.java
@@ -1,6 +1,7 @@
 package com.hufs_cheongwon.web.dto.response;
 
 import com.hufs_cheongwon.common.Constant;
+import com.hufs_cheongwon.common.Util;
 import com.hufs_cheongwon.domain.Link;
 import com.hufs_cheongwon.domain.Petition;
 import com.hufs_cheongwon.domain.enums.Category;
@@ -50,7 +51,7 @@ public class PetitionResponse {
                 .agreeCount(petition.getAgreeCount())
                 .viewCount(petition.getViewCount())
                 .reportCount(petition.getReportCount())
-                .writerEmail(petition.getUsers().getEmail())
+                .writerEmail(Util.maskEmail(petition.getUsers().getEmail()))
                 .links(linkList)
                 .createDate(petition.getCreatedAt().toLocalDate())
                 .endDate(petition.getCreatedAt().toLocalDate().plus(Constant.PETITION_ACTIVE_PERIOD))
@@ -75,7 +76,7 @@ public class PetitionResponse {
                 .agreeCount(petition.getAgreeCount())
                 .viewCount(petition.getViewCount())
                 .reportCount(petition.getReportCount())
-                .writerEmail(petition.getUsers().getEmail())
+                .writerEmail(Util.maskEmail(petition.getUsers().getEmail()))
                 .links(linkList)
                 .createDate(petition.getCreatedAt().toLocalDate())
                 .endDate(petition.getCreatedAt().toLocalDate().plus(Constant.PETITION_ACTIVE_PERIOD))


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->
#47 
## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 응답값에서 사용자 이메일 마스킹 처리
- 로그인 실패할 시 실패 원인 알 수 없도록 수정
- soft delete로 변경

회원 탈퇴 흐름
탈퇴 -> UserStatus INACTIVE로 변경 -> 탈퇴한 지 30일이 지난 유저는 UserStatus DELETE로 변경 후, 사용자 정보 지움

유저 정보를 바로 지우면 계속 다시 회원가입을 할 수 있게 돼서 30일 정도 사용자 정보 가지고 있다가 30일 내로 다시 회원가입 시도할 시, 원래 있던 계정을 활성화 시켜줄 수 있도록 했습니다.

스케쥴러 확인을 위해 일단 1일로 설정해두었어여