### PR TITLE
[Feature]: 작성 및 동의한 청원 api 구현

### DIFF
--- a/src/main/java/com/hufs_cheongwon/repository/PetitionRepository.java
+++ b/src/main/java/com/hufs_cheongwon/repository/PetitionRepository.java
@@ -1,6 +1,7 @@
 package com.hufs_cheongwon.repository;
 
 import com.hufs_cheongwon.domain.Petition;
+import com.hufs_cheongwon.domain.Users;
 import com.hufs_cheongwon.domain.enums.PetitionStatus;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -22,6 +23,8 @@ public interface PetitionRepository extends JpaRepository<Petition, Long> {
     Page<Petition> findByPetitionStatusOrderByCreatedAtDesc(PetitionStatus status, Pageable pageable);
 
     Page<Petition> findByPetitionStatusOrderByAgreeCountDesc(PetitionStatus status, Pageable pageable);
+
+    Page<Petition> findByUsers(Users user, Pageable pageable);
 
     /**
      * 진행중인 청원 가져오기
@@ -97,7 +100,13 @@ public interface PetitionRepository extends JpaRepository<Petition, Long> {
     Optional<Petition> findPetitionByResponseId(@Param("responseId") Long responseId);
 
     /**
-     * 특정 사용자가 작성한 청원 중 가장 최근에 작성된 청원 하나를 조회합니다
+     * 특정 사용자가 작성한 청원 중 가장 최근에 작성된 청원 하나를 조회
      */
     Optional<Petition> findTopByUsersIdOrderByCreatedAtDesc(Long userId);
+
+    /**
+     * 특정 사용자가 동의한 청원 조회
+     */
+    @Query("SELECT a.petition FROM Agreement a WHERE a.users.id = :userId")
+    Page<Petition> findPetitionsByUserAgreements(@Param("userId") Long userId, Pageable pageable);
 }

--- a/src/main/java/com/hufs_cheongwon/web/controller/PetitionController.java
+++ b/src/main/java/com/hufs_cheongwon/web/controller/PetitionController.java
@@ -303,4 +303,18 @@ public class PetitionController {
         Page<PetitionResponse> responses = petitionService.getBookmarkedPetitions(customUserDetails.getUser(), pageable);
         return ApiResponse.onSuccess(SuccessStatus.PETITION_BOOKMARKS_RETRIEVED, responses);
     }
+
+    /**
+     * 사용자가 작성한 청원과 동의한 청원을 한 번에 조회
+     */
+    @GetMapping("/my-activities")
+    public ApiResponse<UserPetitionsResponse> getUserPetitionActivities(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @RequestParam(name = "page",defaultValue = "0") int page,
+            @RequestParam(name = "size",defaultValue = "10") int size) {
+
+        Pageable pageable = PageRequest.of(page, size);
+        UserPetitionsResponse response = petitionService.findUserPetitionActivities(customUserDetails.getUser().getId(), pageable);
+        return ApiResponse.onSuccess(SuccessStatus.USER_INFO_RETRIEVED, response);
+    }
 }

--- a/src/main/java/com/hufs_cheongwon/web/dto/response/UserPetitionsResponse.java
+++ b/src/main/java/com/hufs_cheongwon/web/dto/response/UserPetitionsResponse.java
@@ -1,0 +1,12 @@
+package com.hufs_cheongwon.web.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+@Getter
+@Builder
+public class UserPetitionsResponse {
+    private Page<PetitionResponse> writtenPetitions;  // 사용자가 작성한 청원
+    private Page<PetitionResponse> agreedPetitions;   // 사용자가 동의한 청원
+}

--- a/src/main/resources/templates/email-template.html
+++ b/src/main/resources/templates/email-template.html
@@ -26,9 +26,6 @@
             인증번호는 발송 시점으로부터 10분 동안 유효합니다.
         </p>
 
-        <div style="text-align: center; margin: 30px 0;">
-            <a style="background-color: #00205b; color: #ffffff; padding: 12px 25px; text-decoration: none; border-radius: 4px; font-weight: bold; display: inline-block; font-size: 14px;" href="#" target="_blank">한국외대 신문고 바로가기</a>
-        </div>
     </div>
 
     <!-- 푸터 -->


### PR DESCRIPTION
## #️⃣ Issue Number

- #49

## 📝 요약(Summary)

- 동의한 청원과 작성한 청원 dto 하나로 두어 반환
- dto 내부에 Page 객체는 따로 두어 구분 가능

